### PR TITLE
[FEAT] 프로필 조회 API 분리 (me, other)

### DIFF
--- a/src/main/java/team/wego/wegobackend/common/security/JwtAuthenticationFilter.java
+++ b/src/main/java/team/wego/wegobackend/common/security/JwtAuthenticationFilter.java
@@ -130,6 +130,10 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         }
 
         //TODO : PUBLIC_PATTERNS 관리 포인트 개선 필요 (메서드까지 관리 확장)
+        if(pathMatcher.match("/api/v1/users/me", path)) {
+            return false;
+        }
+
         if ("GET".equals(method) && pathMatcher.match("/api/v1/users/**", path)) {
             return true;
         }

--- a/src/main/java/team/wego/wegobackend/common/security/SecurityConfig.java
+++ b/src/main/java/team/wego/wegobackend/common/security/SecurityConfig.java
@@ -35,6 +35,7 @@ public class SecurityConfig {
         http
                 .cors(cors -> cors.configurationSource(corsConfigurationSource()))
                 .authorizeHttpRequests((auth) -> auth
+                        .requestMatchers("/api/v1/users/me").authenticated()
                         .requestMatchers(HttpMethod.GET, "/api/v1/users/**").permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/v*/groups/**").permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/v*/groups").permitAll()

--- a/src/main/java/team/wego/wegobackend/user/application/UserService.java
+++ b/src/main/java/team/wego/wegobackend/user/application/UserService.java
@@ -29,6 +29,15 @@ public class UserService {
     private final ImageUploadService imageUploadService;
 
     @Transactional(readOnly = true)
+    public UserInfoResponse getProfile(Long userId) {
+
+        User user = userRepository.findById(userId)
+            .orElseThrow(UserNotFoundException::new);
+
+        return UserInfoResponse.from(user);
+    }
+
+    @Transactional(readOnly = true)
     public UserInfoResponse getProfile(Long loginUserId, Long targetUserId) {
 
         User targetUser = userRepository.findById(targetUserId)
@@ -38,9 +47,6 @@ public class UserService {
         if (loginUserId == null || loginUserId.equals(targetUserId)) {
             return UserInfoResponse.from(targetUser);
         }
-
-        User loginUser = userRepository.findById(loginUserId)
-            .orElseThrow(UserNotFoundException::new);
 
         boolean isFollow = followRepository.existsByFollowerIdAndFolloweeId(loginUserId,
             targetUserId);

--- a/src/main/java/team/wego/wegobackend/user/presentation/UserController.java
+++ b/src/main/java/team/wego/wegobackend/user/presentation/UserController.java
@@ -41,7 +41,23 @@ public class UserController implements UserControllerDocs {
     private final FollowService followService;
 
     /**
-     * 프로필 조회
+     * 프로필 조회(me)
+     */
+    @GetMapping("/me")
+    public ResponseEntity<ApiResponse<UserInfoResponse>> profile(
+        @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+
+        UserInfoResponse response = userService.getProfile(userDetails.getId());
+
+        return ResponseEntity
+            .status(HttpStatus.OK)
+            .body(ApiResponse.success(200,
+                response));
+    }
+
+    /**
+     * 프로필 조회(other)
      */
     @GetMapping("/{userId}")
     public ResponseEntity<ApiResponse<UserInfoResponse>> profile(

--- a/src/main/java/team/wego/wegobackend/user/presentation/UserControllerDocs.java
+++ b/src/main/java/team/wego/wegobackend/user/presentation/UserControllerDocs.java
@@ -23,6 +23,11 @@ import team.wego.wegobackend.user.application.dto.response.UserInfoResponse;
 @Tag(name = "유저 API", description = "유저와 관련된 API 리스트 \uD83D\uDC08")
 public interface UserControllerDocs {
 
+    @Operation(summary = "본인 프로필 조회 API", description = "토큰을 통해서 본인 프로필 정보를 조회합니다. (별도 파라메터 없습니다)")
+    ResponseEntity<ApiResponse<UserInfoResponse>> profile(
+        @AuthenticationPrincipal CustomUserDetails userDetails
+    );
+
     @Operation(summary = "유저 프로필 조회 API", description =
         "PathVariable로 들어온 userId에 해당하는 유저 프로필에 대한 응답 \n"
             + "로그인 여부/본인 여부에 따라 팔로우 여부를 null 혹은 true/false로 응답합니다.")


### PR DESCRIPTION
# 📝 Pull Request

## 📌 PR 종류

해당하는 항목에 체크해주세요.

- [ ] 기능 추가 (Feature)
- [ ] 버그 수정 (Fix)
- [ ] 문서 수정 (Docs)
- [x] 코드 리팩터링 (Refactor)
- [ ] 테스트 추가 (Test)
- [ ] 기타 변경 (Chore)

---

## ✨ 변경 내용

프론트측 요청에 따라 본인 프로필 조회, 타인 프로필 조회 엔드포인트를 분리하였습니다.

- ***

## 🔍 관련 이슈

해당 PR이 해결하는 이슈가 있다면 연결해주세요.  

- ***

## 🧪 테스트

변경된 기능에 대한 테스트 범위 또는 테스트 결과를 작성해주세요.

- [ ] 유닛 테스트 추가 / 수정
- [ ] 통합 테스트 검증
- [x] 수동 테스트 완료

---

## 🚨 확인해야 할 사항 (Checklist)

PR을 제출하기 전에 아래 항목들을 확인해주세요.

- [x] 코드 포매팅 완료
- [x] 불필요한 파일/코드 제거
- [x] 로직 검증 완료
- [x] 프로젝트 빌드 성공
- [ ] 린트/정적 분석 통과 (해당 시)

---

## 🙋 기타 참고 사항

리뷰어가 참고하면 좋을 만한 추가 설명이 있다면 적어주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능

* 인증된 사용자가 토큰을 통해 자신의 프로필 정보를 조회할 수 있는 새로운 개인 프로필 조회 엔드포인트 추가
* 기존 사용자 프로필 조회 기능과 별도로 제공되는 전용 엔드포인트 운영

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->